### PR TITLE
Fix builtin commands

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -28,8 +28,8 @@ func Run(name string, args []string) error {
 	defer func() {
 		currentGrift.TearDown()
 	}()
-	if len(args) == 2 {
-		switch args[1] {
+	if len(args) == 1 {
+		switch args[0] {
 		case "jim":
 			jimTribute()
 			return nil


### PR DESCRIPTION
This addresses issue #5 where builtin commands could not be used within inserting a random argument before them.