### PR TITLE
Make grifts more rake-like

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,12 @@ var _ = Add("env:print", func(c *Context) error {
 	return nil
 })
 
-var _ = Desc("db:migrate", "Migrates the databases")
-var _ = Set("db:migrate", func(c *Context) error {
-	fmt.Println("db:migrate")
-	fmt.Printf("### args -> %+v\n", c.Args)
-	return nil
-})
-
+var _ = Namespace("db", func() {
+    Desc("migrate", "Migrates the databases")
+    Set("migrate", func(c *Context) error {
+            fmt.Println("db:migrate")
+            fmt.Printf("### args -> %+v\n", c.Args)
+            return nil
+    })
+}
 ```

--- a/README.md
+++ b/README.md
@@ -40,12 +40,6 @@ When you run the `init` sub-command Grift will generate a new `grifts` package a
 $ grift list
 ```
 
-Grifts without descriptions are not shown by default. To show these, add the `-a` flag.
-
-```text
-$ grift list -a
-```
-
 #### Say Hello!
 
 ```text

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ When you run the `init` sub-command Grift will generate a new `grifts` package a
 $ grift list
 ```
 
+Grifts without descriptions are not shown by default. To show these, add the `-a` flag.
+
+```text
+$ grift list -a
+```
+
 #### Say Hello!
 
 ```text

--- a/grift/grift.go
+++ b/grift/grift.go
@@ -19,8 +19,7 @@ var namespace string
 
 type Grift func(c *Context) error
 
-// Create a namespace. All tasks within the
-// namespace will share the same prefix.
+// Namespace will place all tasks within the given prefix.
 func Namespace(name string, s func()) error {
 	defer func() {
 		namespace = ""
@@ -82,18 +81,18 @@ func Set(name string, grift Grift) error {
 // Rename a grift. Useful if you want to re-define
 // an existing grift, but don't want to write over
 // the original.
-func Rename(old string, new string) error {
+func Rename(oldName string, newName string) error {
 	lock.Lock()
 	defer lock.Unlock()
 
-	old = applyNamespace(old)
-	new = applyNamespace(new)
+	oldName = applyNamespace(oldName)
+	newName = applyNamespace(newName)
 
-	if griftList[old] == nil {
-		return fmt.Errorf("No task named %s defined!", old)
+	if griftList[oldName] == nil {
+		return fmt.Errorf("No task named %s defined!", oldName)
 	}
-	griftList[new] = griftList[old]
-	delete(griftList, old)
+	griftList[newName] = griftList[oldName]
+	delete(griftList, oldName)
 	return nil
 }
 

--- a/grift/grift.go
+++ b/grift/grift.go
@@ -158,11 +158,7 @@ func Exec(args []string, verbose bool) error {
 	}
 	switch name {
 	case "list":
-		var showAll bool
-		if len(args) >= 2 && args[1] == "-a" {
-			showAll = true
-		}
-		PrintGrifts(os.Stdout, showAll)
+		PrintGrifts(os.Stdout)
 	default:
 		c := NewContext(name)
 		c.Verbose = verbose
@@ -176,28 +172,21 @@ func Exec(args []string, verbose bool) error {
 
 // PrintGrifts to the screen, nice, sorted, and with descriptions,
 // should they exist.
-func PrintGrifts(w io.Writer, all bool) {
+func PrintGrifts(w io.Writer) {
 	cnLen := len(CommandName)
 	maxLen := cnLen
 	l := List()
 
 	for _, k := range l {
-		if !all && descriptions[k] == "" {
-			continue
-		}
 		if (len(k) + cnLen) > maxLen {
 			maxLen = len(k) + cnLen
 		}
 	}
 
 	for _, k := range l {
-		if !all && descriptions[k] == "" {
-			continue
-		}
 		m := strings.Join([]string{CommandName, k}, " ")
 		suffix := strings.Repeat(" ", (maxLen+3)-len(m)) + " #"
 
 		fmt.Fprintln(w, strings.Join([]string{m, suffix, descriptions[k]}, " "))
-
 	}
 }

--- a/grift/grift_test.go
+++ b/grift/grift_test.go
@@ -188,12 +188,12 @@ func Test_PrintGrifts(t *testing.T) {
 	})
 
 	bb := &bytes.Buffer{}
-	PrintGrifts(bb)
+	PrintGrifts(bb, false)
+	r.Equal("grift a    # AH!\n", bb.String())
 
-	act := "grift a | AH!\ngrift b\n"
-
-	r.Equal(act, bb.String())
-
+	bb = &bytes.Buffer{}
+	PrintGrifts(bb, true)
+	r.Equal("grift a    # AH!\ngrift b    # \n", bb.String())
 	reset()
 }
 

--- a/grift/grift_test.go
+++ b/grift/grift_test.go
@@ -188,11 +188,7 @@ func Test_PrintGrifts(t *testing.T) {
 	})
 
 	bb := &bytes.Buffer{}
-	PrintGrifts(bb, false)
-	r.Equal("grift a    # AH!\n", bb.String())
-
-	bb = &bytes.Buffer{}
-	PrintGrifts(bb, true)
+	PrintGrifts(bb)
 	r.Equal("grift a    # AH!\ngrift b    # \n", bb.String())
 	reset()
 }

--- a/grift/grift_test.go
+++ b/grift/grift_test.go
@@ -138,6 +138,44 @@ func Test_List(t *testing.T) {
 	reset()
 }
 
+func Test_Namespace(t *testing.T) {
+	r := require.New(t)
+	Add("b", func(c *Context) error {
+		return nil
+	})
+	Add("c", func(c *Context) error {
+		return nil
+	})
+
+	Namespace("a", func() {
+		Add("a", func(c *Context) error {
+			return nil
+		})
+		Add("d", func(c *Context) error {
+			return nil
+		})
+
+		Remove("b")
+		Remove(":c")
+
+		Namespace("e", func() {
+			Add("f", func(c *Context) error {
+				return nil
+			})
+
+			Rename("f", "g")
+
+			Remove(":d")
+
+		})
+
+	})
+
+	r.Equal([]string{"a:a", "a:d", "a:e:g", "b"}, List())
+
+	reset()
+}
+
 func Test_PrintGrifts(t *testing.T) {
 	r := require.New(t)
 
@@ -195,4 +233,5 @@ func Test_Exec(t *testing.T) {
 func reset() {
 	griftList = map[string]Grift{}
 	descriptions = map[string]string{}
+	namespace = ""
 }


### PR DESCRIPTION
This change adds the concept of namespaces, which work similar to the way rake uses them. This is mostly syntactic sugar around prefixing every task with a common string.

Instead of:
```go
var _ = Add("db:migrate", func(c *Context) error{
    return nil
})

var _ = Add("db:backup", func(c *Context) error{
    return nil
})
```

You can now simplify that:
```go
var _ = Namespace("db", func(){
    Add("migrate", func(c *Context) error{
        return nil
    })

    Add("backup", func(c *Context) error{
        return nil
    })
})
```

All grift functions within the namespace are affected by the scope of the namespace.

I've also modified the list command to make it look and behave more like the output of `rake -T`. This now ignores tasks without descriptions and aligns the descriptions when they are present.

```
$ grift list
grift env:print    # Prints out all of the ENV variables in your environment. Pass in the name of a particular ENV variable to print just that one out. (e.g. grift env:print GOPATH)

$ grift list -a
grift env:print         # Prints out all of the ENV variables in your environment. Pass in the name of a particular ENV variable to print just that one out. (e.g. grift env:print GOPATH)
grift foo:hellothing    # 
grift hello             # 

```