### PR TITLE
Add grifts directory hunting

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/markbates/grift/cmd"
@@ -9,6 +10,7 @@ import (
 func main() {
 	err := cmd.Run("grift", os.Args[1:])
 	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
Instead of requiring grifts to run at the top-level directory, it can now be executed in any subdirectory of the current package and the grifts directory will be found if it exists.

Consider the following tree:
```
.
├── LICENSE
├── README.md
├── cmd
│   ├── gen.go
│   ├── grifter.go
│   ├── jim.go
│   ├── run.go
│   ├── templates.go
│   └── version.go
├── grift
│   ├── context.go
│   ├── grift.go
│   └── grift_test.go
├── grifts
│   └── example.go
└── main.go

3 directories, 13 files
```

Without this change, you must be at the root of this project to get access to the tasks defined in `grifts/example.go`. An attempt to run `grift list` will return an error.

By hunting up through the tree, you now have access to your grift tasks from any subdirectory.

```
$ cd cmd
$ grift list
grift env:print | Prints out all of the ENV variables in your environment. Pass in the name of a particular ENV variable to print just that one out. (e.g. grift env:print GOPATH)
grift hello
```

