### PR TITLE
Change directory to the parent of the grifts directory

### DIFF
--- a/cmd/grifter.go
+++ b/cmd/grifter.go
@@ -15,9 +15,10 @@ const exePath = ".grifter/main.go"
 var once = &sync.Once{}
 
 type grifter struct {
-	GriftsPackagePath string
-	CommandName       string
-	Verbose           bool
+	GriftsPackagePath  string
+	CommandName        string
+	Verbose            bool
+	GriftsAbsolutePath string
 }
 
 func hasGriftDir(path string) bool {
@@ -59,7 +60,7 @@ func newGrifter(name string) (*grifter, error) {
 	if len(p) == 1 {
 		return g, errors.Errorf("There is no directory named 'grifts'. Run '%s init' or switch to the appropriate directory", name)
 	}
-
+	g.GriftsAbsolutePath = filepath.ToSlash(filepath.Join(path, "grifts"))
 	g.GriftsPackagePath = filepath.ToSlash(filepath.Join(p[1], "grifts"))
 	return g, nil
 }

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -7,9 +7,13 @@ import _ "{{.GriftsPackagePath}}"
 import "os"
 import "log"
 import "github.com/markbates/grift/grift"
+import "path/filepath"
 
 func main() {
 	grift.CommandName = "{{.CommandName}}"
+	if err := os.Chdir(filepath.Dir("{{.GriftsAbsolutePath}}")); err != nil {
+	  log.Fatal(err)
+	}
 	err := grift.Exec(os.Args[1:], false)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This makes it easier to predict the path when creating tasks. Since you can now run your grifts from any subdirectory of your project, you can't predict the current working directory.

This makes it a real challenge to have your tasks load relative paths. Instead of pushing that complexity into the authors of the tasks we just change to the parent of the grifts directory.