### PR TITLE
Minor task issue caused by path resolution.

### DIFF
--- a/cmd/grifter.go
+++ b/cmd/grifter.go
@@ -56,7 +56,7 @@ func newGrifter(name string) (*grifter, error) {
 		path = filepath.Dir(path)
 	}
 
-	p := strings.SplitN(path, "/src/", 2)
+	p := strings.SplitN(path, filepath.FromSlash("/src/"), 2)
 	if len(p) == 1 {
 		return g, errors.Errorf("There is no directory named 'grifts'. Run '%s init' or switch to the appropriate directory", name)
 	}


### PR DESCRIPTION
I finally discovered the issue with the grift task on windows was because the path was not being resolved for windows.

I installed buffalo with this change and it worked.