### PR TITLE
Fix broken test

### DIFF
--- a/grift/grift_test.go
+++ b/grift/grift_test.go
@@ -198,19 +198,15 @@ func Test_Exec(t *testing.T) {
 
 	var name string
 	var args []string
-	Add("default", func(c *Context) error {
-		name = c.Name
-		args = c.Args
-		return nil
-	})
+
 	Add("hello", func(c *Context) error {
 		name = c.Name
 		args = c.Args
 		return nil
 	})
-	t.Run("default", func(st *testing.T) {
+	t.Run("list", func(st *testing.T) {
 		Exec([]string{}, false)
-		r.Equal("default", name)
+		r.Equal("", name)
 		r.Empty(args)
 	})
 	t.Run("name grift", func(st *testing.T) {


### PR DESCRIPTION
Tests broke on https://github.com/markbates/grift/commit/784845c09462d47ab2b1ebe338040f64a1c45cc5 .
This makes the tests green again, though i'm not 100% sure this was the original intent of the tests.