### PR TITLE
Make it explicit that the grifts listed are actually just listed

### DIFF
--- a/grift/grift.go
+++ b/grift/grift.go
@@ -173,6 +173,8 @@ func Exec(args []string, verbose bool) error {
 // PrintGrifts to the screen, nice, sorted, and with descriptions,
 // should they exist.
 func PrintGrifts(w io.Writer) {
+	fmt.Fprint(w, "Available grifts\n================\n")
+
 	cnLen := len(CommandName)
 	maxLen := cnLen
 	l := List()

--- a/grift/grift_test.go
+++ b/grift/grift_test.go
@@ -189,7 +189,7 @@ func Test_PrintGrifts(t *testing.T) {
 
 	bb := &bytes.Buffer{}
 	PrintGrifts(bb)
-	r.Equal("grift a    # AH!\ngrift b    # \n", bb.String())
+	r.Equal("Available grifts\n================\ngrift a    # AH!\ngrift b    # \n", bb.String())
 	reset()
 }
 


### PR DESCRIPTION
Showing the list of the grifts when running "grift" can led the user to
believe that all grifts were executed rather than just listed, this
solves the issue by telling the user that it's just a list