### PR TITLE
Source run

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 
+	"github.com/markbates/grift/grift"
 	"github.com/pkg/errors"
 )
 
@@ -47,25 +47,15 @@ func Run(name string, args []string) error {
 func run(args []string) error {
 	rargs := []string{"run", exePath}
 	rargs = append(rargs, args...)
-	runner := exec.Command("go", rargs...)
-	runner.Stdin = os.Stdin
-	runner.Stdout = os.Stdout
-	runner.Stderr = os.Stderr
-	err := runner.Run()
-	if err != nil {
+	if err := grift.RunSource(exec.Command("go", rargs...)); err != nil {
 		return errors.WithStack(err)
 	}
-
 	return nil
 }
 
 func list() error {
 	rargs := []string{"run", exePath, "list"}
-	runner := exec.Command("go", rargs...)
-	runner.Stderr = os.Stderr
-	runner.Stdin = os.Stdin
-	runner.Stdout = os.Stdout
-	return runner.Run()
+	return grift.RunSource(exec.Command("go", rargs...))
 }
 
 func setup(name string) error {

--- a/grift/grift.go
+++ b/grift/grift.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"sort"
 	"strings"
 	"sync"
@@ -195,4 +196,12 @@ func PrintGrifts(w io.Writer) {
 
 		fmt.Fprintln(w, strings.Join([]string{m, suffix, descriptions[k]}, " "))
 	}
+}
+// RunSource executes the command passed as argument,
+// in the current shell/context
+func RunSource(cmd exec.Command) error{
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	return cmd.Run()
 }

--- a/grift/grift.go
+++ b/grift/grift.go
@@ -197,9 +197,10 @@ func PrintGrifts(w io.Writer) {
 		fmt.Fprintln(w, strings.Join([]string{m, suffix, descriptions[k]}, " "))
 	}
 }
+
 // RunSource executes the command passed as argument,
 // in the current shell/context
-func RunSource(cmd exec.Command) error{
+func RunSource(cmd *exec.Cmd) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
It's a handy utility named after the 'source' bash command that aims to remove lot's of boilerplate code found throughout grift itself and other programs that use grift. If you look at current **run.go** on the diff or for example at [pop/grifts](https://github.com/markbates/pop/blob/master/grifts/release.go) you can spot this pattern.

I believe that this is the correct place for this, because whenever making grifts/importing grift to the current namespace, it is common to run commands in this manner.  :)