### PR TITLE
Add support for sqlite build tag required by Buffalo.

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os/exec"
 
 	"github.com/markbates/grift/grift"
@@ -45,7 +47,14 @@ func Run(name string, args []string) error {
 }
 
 func run(args []string) error {
-	rargs := []string{"run", exePath}
+	rargs := []string{"run"}
+	// Test for special cases requiring sqlite build tag
+	if b, err := ioutil.ReadFile("database.yml"); err == nil {
+		if bytes.Contains(b, []byte("sqlite")) {
+			rargs = append(rargs, "-tags", "sqlite")
+		}
+	}
+	rargs = append(rargs, exePath)
 	rargs = append(rargs, args...)
 	if err := grift.RunSource(exec.Command("go", rargs...)); err != nil {
 		return errors.WithStack(err)


### PR DESCRIPTION
Tested OK on Windows using SQLite in Buffalo.  I found that fixing it in the Run command worked for both the list case and the run case and it wasn't necessary to change the list() method (it doesn't look like that one is referenced).