### PR TITLE
Add support for sqlite build tag for config/database.yml

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -49,7 +49,11 @@ func Run(name string, args []string) error {
 func run(args []string) error {
 	rargs := []string{"run"}
 	// Test for special cases requiring sqlite build tag
-	if b, err := ioutil.ReadFile("database.yml"); err == nil {
+	b, err := ioutil.ReadFile("database.yml")
+	if err != nil {
+		b, err = ioutil.ReadFile("config/database.yml")
+	}
+	if err == nil {
 		if bytes.Contains(b, []byte("sqlite")) {
 			rargs = append(rargs, "-tags", "sqlite")
 		}


### PR DESCRIPTION

Hi Mark

I'm using `pop` and `grift` in a small project (without buffalo) using sqlite. 

When i use grift to run a command that uses sqlite, i get the error...

```
sqlite3 was not compiled into the binary
```

I see Grift [PR #23](https://github.com/markbates/grift/pull/23/commits/c90ef35a1052806ae19fe1d43a87355e6f81b220) you provided a fix for the case when `database.yml` is in the root directory.

In the [Pop docs](https://github.com/gobuffalo/pop#connecting-to-databases) it says `database.yml` can live in the root or in a `config` folder.

```
Pop is easily configured using a YAML file. The configuration file 
should be stored in config/database.yml or database.yml.
```

For those people that have their `database.yml` in the `config` folder, this PR fixes the issue.

Feel free to implement it better :) The idea is just to check in both locations for the `database.yml` file.

Regards,
Gareth
