### PR TITLE
Fix nested namespaces bug

### DIFF
--- a/grift/grift.go
+++ b/grift/grift.go
@@ -22,8 +22,9 @@ type Grift func(c *Context) error
 
 // Namespace will place all tasks within the given prefix.
 func Namespace(name string, s func()) error {
+	saved := namespace
 	defer func() {
-		namespace = ""
+		namespace = saved
 	}()
 
 	namespace = applyNamespace(name)

--- a/grift/grift_test.go
+++ b/grift/grift_test.go
@@ -151,6 +151,12 @@ func Test_Namespace(t *testing.T) {
 		Add("a", func(c *Context) error {
 			return nil
 		})
+		Add("b", func(c *Context) error {
+			return nil
+		})
+		Add("c", func(c *Context) error {
+			return nil
+		})
 		Add("d", func(c *Context) error {
 			return nil
 		})
@@ -169,9 +175,12 @@ func Test_Namespace(t *testing.T) {
 
 		})
 
+		Add("h", func(c *Context) error {
+			return nil
+		})
 	})
 
-	r.Equal([]string{"a:a", "a:d", "a:e:g", "b"}, List())
+	r.Equal([]string{"a:a", "a:c", "a:d", "a:e:g", "a:h", "b"}, List())
 
 	reset()
 }


### PR DESCRIPTION
When exiting a namespace, just revert that namespace call, not all the way to the root.